### PR TITLE
Add admin button to home page

### DIFF
--- a/DjangoWebProject1/app/templates/app/index.html
+++ b/DjangoWebProject1/app/templates/app/index.html
@@ -2,6 +2,7 @@
 {% block title %}List O' Movies{% endblock %}
 
 {% block content %}
+<a href="{% url 'admin:index' %}" class="btn btn-warning mb-3">Admin Dashboard</a>
 {% if movies %}
     {% for movie in movies %}
         <div class="row bounce">


### PR DESCRIPTION
## Summary
- add 'Admin Dashboard' button to the home page

## Testing
- `python DjangoWebProject1/manage.py test app`

------
https://chatgpt.com/codex/tasks/task_e_6840ec9700608324a078d38c1dfeb29c