### PR TITLE
Add GitHub login integration

### DIFF
--- a/DjangoWebProject1/DjangoWebProject1/settings.py
+++ b/DjangoWebProject1/DjangoWebProject1/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'app',
+    'social_django',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -48,6 +49,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'DjangoWebProject1.urls'
@@ -63,6 +65,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },
@@ -125,5 +129,18 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/images/'
+
+AUTHENTICATION_BACKENDS = (
+    'social_core.backends.github.GithubOAuth2',
+    'django.contrib.auth.backends.ModelBackend',
+)
+
+LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'
+
+SOCIAL_AUTH_GITHUB_KEY = os.environ.get('SOCIAL_AUTH_GITHUB_KEY', '')
+SOCIAL_AUTH_GITHUB_SECRET = os.environ.get('SOCIAL_AUTH_GITHUB_SECRET', '')
+SOCIAL_AUTH_URL_NAMESPACE = 'social'
 
 

--- a/DjangoWebProject1/DjangoWebProject1/urls.py
+++ b/DjangoWebProject1/DjangoWebProject1/urls.py
@@ -16,11 +16,15 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+from django.contrib.auth.views import LogoutView
 from app import views
 
 urlpatterns = [
     path("", views.index, name="home"),
+    path("login/", views.login_view, name="login"),
+    path("logout/", LogoutView.as_view(next_page="/"), name="logout"),
+    path("oauth/", include('social_django.urls', namespace='social')),
     path("admin/", admin.site.urls),
     path("success/", views.success),
     path("createmovie/", views.createmovie, name="createmovie"),

--- a/DjangoWebProject1/app/templates/app/login.html
+++ b/DjangoWebProject1/app/templates/app/login.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<div class="text-center mt-5">
+    <a href="{% url 'social:begin' 'github' %}" class="btn btn-dark">Login with GitHub</a>
+</div>
+{% endblock %}

--- a/DjangoWebProject1/app/templates/base.html
+++ b/DjangoWebProject1/app/templates/base.html
@@ -34,6 +34,12 @@
                     <input class="form-control me-2" name="title" type="search" placeholder="Search" aria-label="Search">
                     <button class="btn btn-outline-success" type="submit">Search</button>
                 </form>
+                {% if request.user.is_authenticated %}
+                    <span class="navbar-text me-2">Hi, {{ request.user.username }}</span>
+                    <a href="{% url 'logout' %}" class="btn btn-outline-danger me-2">Logout</a>
+                {% else %}
+                    <a href="{% url 'login' %}" class="btn btn-outline-primary me-2">Login</a>
+                {% endif %}
                 <a href="{% url 'admin:index' %}" class="btn btn-warning">Admin Dashboard</a>
             </div>
         </div>

--- a/DjangoWebProject1/app/views.py
+++ b/DjangoWebProject1/app/views.py
@@ -76,3 +76,7 @@ def editmovie(request):
 
             return HttpResponseRedirect("/")
         return HttpResponseRedirect("/")
+
+
+def login_view(request):
+    return render(request, "app/login.html")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+django==4.0.4
+social-auth-app-django


### PR DESCRIPTION
## Summary
- create OAuth login view and template
- add GitHub auth configuration in settings
- update URLs for login/logout and social auth
- show login/logout links in the base navbar
- document requirements for social-auth

## Testing
- `python DjangoWebProject1/manage.py test app` *(fails: ModuleNotFoundError: No module named 'social_django')*

------
https://chatgpt.com/codex/tasks/task_e_6841a45ce420832482c743d5368687fa