### PR TITLE
Add dotenv support with sample env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SOCIAL_AUTH_GITHUB_KEY=your_key_here
+SOCIAL_AUTH_GITHUB_SECRET=your_secret_here

--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ http://<host>/oauth/complete/github/
 ```
 
 The `/oauth/` prefix matches the URL configuration in `config/urls.py`.
+
+## Local Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your GitHub OAuth
+credentials:
+
+```
+cp .env.example .env
+# then edit .env to add your values
+```
+
+The application will load these variables automatically when it starts.

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,9 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 import os
 from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==4.0.4
 social-auth-app-django
 Pillow
+python-dotenv


### PR DESCRIPTION
## Summary
- add dotenv support so env vars can be loaded from a `.env` file
- include `python-dotenv` in requirements
- provide `.env.example` and document setup steps

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6841b00638b88324ac57d9ce27a4f61e